### PR TITLE
consume all text

### DIFF
--- a/json.wren
+++ b/json.wren
@@ -9,7 +9,7 @@ class JSON {
   }
 
   static tokenize(string) {
-    return JSONParser.new(string).tokenize
+    return JSONScanner.new(string).tokenize
   }
 }
 
@@ -66,21 +66,9 @@ class JSONParser {
     _tokens = []
   }
 
-  numberChars { "0123456789.-" }
   valueTypes { [Token.String, Token.Number, Token.Bool, Token.Null] }
-  escapedCharMap {
-    return {
-      "\"": "\"",
-      "\\": "\\",
-      "b": "\b",
-      "f": "\f",
-      "n": "\n",
-      "r": "\r",
-      "t": "\t"
-    }
-  }
 
-  parse { nest(tokenize) }
+  parse { nest(JSONScanner.new(_input).tokenize) }
 
   nest(tokens) {
     if (tokens.count == 0) { parsingError }
@@ -132,6 +120,30 @@ class JSONParser {
       return token.value
 
     } else { parsingError }
+  }
+
+  parsingError {
+    Fiber.abort("Invalid JSON")
+  }
+}
+
+class JSONScanner {
+  construct new(input) {
+    _input = input
+    _tokens = []
+  }
+
+  numberChars { "0123456789.-" }
+  escapedCharMap {
+    return {
+      "\"": "\"",
+      "\\": "\\",
+      "b": "\b",
+      "f": "\f",
+      "n": "\n",
+      "r": "\r",
+      "t": "\t"
+    }
   }
 
   tokenize {

--- a/json.wren
+++ b/json.wren
@@ -138,7 +138,7 @@ class JSONScanner {
   }
 
   numberChars { "0123456789.-" }
-  whitespace { " \r\t\n"}
+  whitespaceChars { " \r\t\n"}
   escapedCharMap {
     return {
       "\"": "\"",
@@ -184,7 +184,7 @@ class JSONScanner {
       scanNumber()
     } else if (isAlpha(char)) {
       scanIdentifier()
-    } else if (whitespace.contains(char)) {
+    } else if (whitespaceChars.contains(char)) {
       // pass
     } else {
       parsingError

--- a/json.wren
+++ b/json.wren
@@ -153,9 +153,9 @@ class JSONParser {
     var valueInProgress = []
     var lastIndex = _input.count - 1
 
-    var i = 0
-    while (i < _input.count) {
-      var char = _input[i]
+    var cursor = 0
+    while (cursor < _input.count) {
+      var char = _input[cursor]
 
       if (inString) {
 
@@ -164,14 +164,14 @@ class JSONParser {
             valueInProgress.add(escapedCharMap[char])
           } else if (char == "u") { // unicode char!
             var charsToPull = 4
-            var start = i + 1
+            var start = cursor + 1
             var hexString = Helper.slice(_input, start, start + charsToPull).join("")
 
             var decimal = Helper.hexToDecimal(hexString)
             if (decimal == null) parsingError
             valueInProgress.add(String.fromCodePoint(decimal))
 
-            i = i + charsToPull
+            cursor = cursor + charsToPull
           } else {
             parsingError
           }
@@ -198,7 +198,7 @@ class JSONParser {
         }
 
         // Check last index to support bare numbers
-        if (!numberChars.contains(char) || i == lastIndex) {
+        if (!numberChars.contains(char) || cursor == lastIndex) {
           var number = Num.fromString(valueInProgress.join(""))
 
           if (number == null) {
@@ -213,13 +213,13 @@ class JSONParser {
           // Since there's no terminal char for a Num, we have to wait
           // until we run into a non-Num char. Then, we back up, so that
           // char gets processed
-          i = i - 1
+          cursor = cursor - 1
         }
       } else if (numberChars.contains(char)) {
         valueInProgress.add(char)
         inNumber = true
 
-        var peek = i < (_input.count - 1) ? _input[i + 1] : null
+        var peek = cursor < (_input.count - 1) ? _input[cursor + 1] : null
         if (char == "0" && peek == "x") {
           // Don't allow hex numbers
           parsingError
@@ -246,7 +246,7 @@ class JSONParser {
         // Don't allow comments
         parsingError
       } else {
-        var slicedInput = Helper.slice(_input, i).join("")
+        var slicedInput = Helper.slice(_input, cursor).join("")
         if (slicedInput.startsWith("true")) {
           addToken(tokenBool, true)
         } else if (slicedInput.startsWith("false")) {
@@ -256,7 +256,7 @@ class JSONParser {
         }
       }
 
-      i = i + 1
+      cursor = cursor + 1
     }
 
     return _tokens

--- a/json.wren
+++ b/json.wren
@@ -66,18 +66,8 @@ class JSONParser {
     _tokens = []
   }
 
-  tokenLeftBracket { "LEFT_BRACKET" }
-  tokenRightBracket { "RIGHT_BRACKET" }
-  tokenLeftBrace { "LEFT_BRACE" }
-  tokenRightBrace { "RIGHT_BRACE" }
-  tokenColon { "COLON" }
-  tokenComma { "COMMA" }
-  tokenString { "STRING" }
-  tokenNumber { "NUMBER" }
-  tokenBool { "BOOL" }
-  tokenNull { "NULL"}
   numberChars { "0123456789.-" }
-  valueTypes { [tokenString, tokenNumber, tokenBool, tokenNull] }
+  valueTypes { [Token.String, Token.Number, Token.Bool, Token.Null] }
   escapedCharMap {
     return {
       "\"": "\"",
@@ -97,43 +87,43 @@ class JSONParser {
 
     var token = tokens.removeAt(0)
 
-    if (token.type == tokenLeftBrace) {
+    if (token.type == Token.LeftBrace) {
       // Making a Map
       var map = {}
 
-      while (tokens[0].type != tokenRightBrace) {
+      while (tokens[0].type != Token.RightBrace) {
         var key = tokens.removeAt(0)
-        if (key.type != tokenString) { parsingError }
+        if (key.type != Token.String) { parsingError }
 
-        if ((tokens.removeAt(0)).type != tokenColon) { parsingError }
+        if ((tokens.removeAt(0)).type != Token.Colon) { parsingError }
 
         var value = nest(tokens)
         map[key.value] = value
 
         if (tokens.count >= 2 &&
-            tokens[0].type == tokenComma &&
-            tokens[1].type != tokenRightBrace) {
+            tokens[0].type == Token.Comma &&
+            tokens[1].type != Token.RightBrace) {
           tokens.removeAt(0)
         }
       }
 
-      // Remove tokenRightBrace
+      // Remove Token.RightBrace
       tokens.removeAt(0)
 
       return map
 
-    } else if (token.type == tokenLeftBracket) {
+    } else if (token.type == Token.LeftBracket) {
       // Making a List
       var list = []
-      while (tokens[0].type != tokenRightBracket) {
+      while (tokens[0].type != Token.RightBracket) {
         list.add(nest(tokens))
 
-        if (tokens[0].type == tokenComma) {
+        if (tokens[0].type == Token.Comma) {
           tokens.removeAt(0)
         }
       }
 
-      // Remove tokenRightBracket
+      // Remove Token.RightBracket
       tokens.removeAt(0)
 
       return list
@@ -181,7 +171,7 @@ class JSONParser {
           isEscaping = true
 
         } else if (char == "\"") {
-          addToken(tokenString, valueInProgress.join(""))
+          addToken(Token.String, valueInProgress.join(""))
           valueInProgress = []
           inString = false
 
@@ -204,7 +194,7 @@ class JSONParser {
           if (number == null) {
             parsingError
           } else {
-            addToken(tokenNumber, number)
+            addToken(Token.Number, number)
           }
 
           valueInProgress = []
@@ -226,33 +216,33 @@ class JSONParser {
         }
 
       } else if (char == "{") {
-        addToken(tokenLeftBrace)
+        addToken(Token.LeftBrace)
 
       } else if (char == "}") {
-        addToken(tokenRightBrace)
+        addToken(Token.RightBrace)
 
       } else if (char == "[") {
-        addToken(tokenLeftBracket)
+        addToken(Token.LeftBracket)
 
       } else if (char == "]") {
-        addToken(tokenRightBracket)
+        addToken(Token.RightBracket)
 
       } else if (char == ":") {
-        addToken(tokenColon)
+        addToken(Token.Colon)
 
       } else if (char == ",") {
-        addToken(tokenComma)
+        addToken(Token.Comma)
       } else if (char == "/") {
         // Don't allow comments
         parsingError
       } else {
         var slicedInput = Helper.slice(_input, cursor).join("")
         if (slicedInput.startsWith("true")) {
-          addToken(tokenBool, true)
+          addToken(Token.Bool, true)
         } else if (slicedInput.startsWith("false")) {
-          addToken(tokenBool, false)
+          addToken(Token.Bool, false)
         } else if (slicedInput.startsWith("null")) {
-          addToken(tokenNull, null)
+          addToken(Token.Null, null)
         }
       }
 
@@ -271,6 +261,17 @@ class JSONParser {
 }
 
 class Token {
+  static LeftBracket { "LEFT_BRACKET" }
+  static RightBracket { "RIGHT_BRACKET" }
+  static LeftBrace { "LEFT_BRACE" }
+  static RightBrace { "RIGHT_BRACE" }
+  static Colon { "COLON" }
+  static Comma { "COMMA" }
+  static String { "STRING" }
+  static Number { "NUMBER" }
+  static Bool { "BOOL" }
+  static Null { "NULL"}
+
   construct new(type, value) {
     _type = type
     _value = value

--- a/json.wren
+++ b/json.wren
@@ -195,7 +195,7 @@ class JSONScanner {
     var isEscaping = false
     var valueInProgress = []
 
-    while (peek() != "\"" && !isAtEnd()) {
+    while ((peek() != "\"" || isEscaping) && !isAtEnd()) {
       var char = advance()
 
       if (isEscaping) {
@@ -203,7 +203,7 @@ class JSONScanner {
           valueInProgress.add(escapedCharMap[char])
         } else if (char == "u") { // unicode char!
           var charsToPull = 4
-          var start = _cursor + 1
+          var start = _cursor
           var hexString = Helper.slice(_input, start, start + charsToPull).join("")
 
           var decimal = Helper.hexToDecimal(hexString)

--- a/test/suite.wren
+++ b/test/suite.wren
@@ -13,16 +13,16 @@ var TestJSON = Suite.new("JSON") { |it|
       Expect.call(tokens.count).toEqual(17)
       for (token in tokens) { Expect.call(token).toBe(Token) }
 
-      Expect.call(tokens[0].type).toEqual(parser.tokenLeftBrace)
-      Expect.call(tokens[1].type).toEqual(parser.tokenString)
-      Expect.call(tokens[2].type).toEqual(parser.tokenColon)
-      Expect.call(tokens[3].type).toEqual(parser.tokenNumber)
-      Expect.call(tokens[4].type).toEqual(parser.tokenComma)
+      Expect.call(tokens[0].type).toEqual(Token.LeftBrace)
+      Expect.call(tokens[1].type).toEqual(Token.String)
+      Expect.call(tokens[2].type).toEqual(Token.Colon)
+      Expect.call(tokens[3].type).toEqual(Token.Number)
+      Expect.call(tokens[4].type).toEqual(Token.Comma)
     }
 
     it.should("handle unicode characters") {
       var tokens = JSON.tokenize("\"\\u2618\"")
-      Expect.call(tokens[0].type).toEqual(parser.tokenString)
+      Expect.call(tokens[0].type).toEqual(Token.String)
       Expect.call(tokens[0].value).toEqual("☘")
     }
   }

--- a/test/suite.wren
+++ b/test/suite.wren
@@ -8,6 +8,26 @@ var TestJSON = Suite.new("JSON") { |it|
 
   it.suite("tokenize") { |it|
     it.should("handle basic string") {
+      var tokens = JSON.tokenize("\"sup\"")
+      Expect.call(tokens.count).toEqual(1)
+      Expect.call(tokens[0].type).toEqual(Token.String)
+    }
+
+    it.should("handle basic number") {
+      var tokens = JSON.tokenize("3")
+      Expect.call(tokens.count).toEqual(1)
+      Expect.call(tokens[0].type).toEqual(Token.Number)
+      Expect.call(tokens[0].value).toEqual(3)
+    }
+
+    it.should("handle basic bool") {
+      var tokens = JSON.tokenize("false")
+      Expect.call(tokens.count).toEqual(1)
+      Expect.call(tokens[0].type).toEqual(Token.Bool)
+      Expect.call(tokens[0].value).toEqual(false)
+    }
+
+    it.should("handle basic map") {
       var tokens = JSON.tokenize(mapString)
 
       Expect.call(tokens.count).toEqual(17)

--- a/test/suite.wren
+++ b/test/suite.wren
@@ -284,6 +284,11 @@ var TestJSON = Suite.new("JSON") { |it|
       var value = JSON.parse("{\"\\u2618\": 11}")
       Expect.call(value["☘"]).toEqual(11)
     }
+
+    it.should("throw for extraneous text") {
+      var fiberWithError = Fiber.new { JSON.parse("{\"wow\" nonsense :1}") }
+      Expect.call(fiberWithError).toBeARuntimeError("Invalid JSON")
+    }
   }
 }
 


### PR DESCRIPTION
a lot of this was inspired by #7. the improved error messages made me realize where the scanner was falling short.

`tokenize` would let extraneous characters fall thru instead of enforcing expectations. `JSONScanner` was extracted into its own class to expand its logic. now, instead of just keeping track of a `_cursor`, it also tracks a `_start` which only advances past characters once they're fully consumed.

parsing each multi-char token is split into its own function, allowing the sub-parser to manage its own state. this should allow it to more carefully comb thru each character and enforce expectations along the way. i'm guessing, at this point, there are still some cracks to slip thru, but this is a step in the right direction