### PR TITLE
escape control characters

### DIFF
--- a/json.wren
+++ b/json.wren
@@ -41,6 +41,11 @@ class JSONStringifier {
           substrings.add("\\r")
         } else if (char == "\t") {
           substrings.add("\\t")
+        } else if (char.bytes[0] <= 0x1f) {
+          // Control characters!
+          var byte = char.bytes[0]
+          var hex = Helper.lpad(Helper.toHex(byte), 4, "0")
+          substrings.add("\\u" + hex)
         } else {
           substrings.add(char)
         }
@@ -338,6 +343,10 @@ class Token {
   index { _index }
 }
 
+var HEX_CHARS = [
+  "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"
+]
+
 // TODO: use Pure when we have a nice module system
 class Helper {
   static slice(list, start) {
@@ -362,6 +371,21 @@ class Helper {
       power = power + 1
     }
     return result
+  }
+  static toHex(byte) {
+    var hex = ""
+    while (byte > 0) {
+      var c = byte % 16
+      hex = HEX_CHARS[c] + hex
+      byte = byte >> 4
+    }
+    return hex
+  }
+  static lpad(s, count, with) {
+    while (s.count < count) {
+      s = "%(with)%(s)"
+    }
+    return s
   }
   static reverse (str) {
     var result = ""

--- a/test/suite.wren
+++ b/test/suite.wren
@@ -216,6 +216,10 @@ var TestJSON = Suite.new("JSON") { |it|
     it.should("handle horizontal tabs in strings") {
       Expect.call(JSON.stringify("hey \t man")).toEqual("\"hey \\t man\"")
     }
+
+    it.should("escape control characters") {
+      Expect.call(JSON.stringify(String.fromByte(1))).toEqual("\"\\u0001\"")
+    }
   }
 
   it.suite("edge cases") { |it|


### PR DESCRIPTION
fixes #10 with code provided by @joshgoebel. 

I tracked down the details in the [JSON RFC](https://www.ietf.org/rfc/rfc4627.txt).

    2.5.  Strings

    The representation of strings is similar to conventions used in the C
    family of programming languages.  A string begins and ends with
    quotation marks.  All Unicode characters may be placed within the
    quotation marks except for the characters that must be escaped:
    quotation mark, reverse solidus, and the control characters (U+0000
    through U+001F).
